### PR TITLE
Fixed clear issue for events on the nav bar

### DIFF
--- a/src/scripts/domAppender.js
+++ b/src/scripts/domAppender.js
@@ -21,7 +21,7 @@ const domAppender = {
     navBar.appendChild(domStructure.nav.createNavBar());
     }
   },
-  home: {
+  tasks: {
     createDOM() {
       console.log("home")
     }

--- a/src/scripts/domAppender.js
+++ b/src/scripts/domAppender.js
@@ -33,7 +33,11 @@ const domAppender = {
   },
   events: {
     createDOM() {
-      event.appendEventForm();
+      
+      while (mainContainer.firstChild) {
+        mainContainer.removeChild(mainContainer.firstChild);
+      };
+      mainContainer.appendChild(event.appendEventForm());
     }
   },
   messages: {

--- a/src/scripts/eventsAppender.js
+++ b/src/scripts/eventsAppender.js
@@ -4,11 +4,13 @@ import buildEventForm from "./eventsDomManager";
 const eventsAppender = {
     appendEventForm() {
         // Selects the container with the id of events-section and assigns it to the variable eventSection
-        let eventSection = document.querySelector("#events-section");
+        let eventSection = document.createElement("section");
+        eventSection.id = "events-section";
         // Appends the  add button, form and save button from eventsDomManager.js to the DOM
         eventSection.appendChild(buildEventForm.buildEventButton());
         eventSection.appendChild(buildEventForm.buildEventForm());
         eventSection.appendChild(buildEventForm.eventSaveButton());
+        return eventSection;
     }
 
 };

--- a/src/scripts/eventsDomManager.js
+++ b/src/scripts/eventsDomManager.js
@@ -6,7 +6,7 @@ const buildEventFormHTML = {
     buildEventButton() {
         const createEventsButton = buildHTML.buttonCreator("eventsButton", "Add New Event", undefined);
         // Event listener console logs 'clicked' when clicked to demonstrate that it works. Event handler has yet to be added.
-        createEventsButton.addEventListener("click", addNewEventHandler);
+        createEventsButton.addEventListener("click", () => console.log("wow what a dream"));
         return createEventsButton
     },
     buildEventForm() {

--- a/src/scripts/eventsDomManager.js
+++ b/src/scripts/eventsDomManager.js
@@ -6,7 +6,7 @@ const buildEventFormHTML = {
     buildEventButton() {
         const createEventsButton = buildHTML.buttonCreator("eventsButton", "Add New Event", undefined);
         // Event listener console logs 'clicked' when clicked to demonstrate that it works. Event handler has yet to be added.
-        createEventsButton.addEventListener("click", () => console.log("clicked"));
+        createEventsButton.addEventListener("click", addNewEventHandler);
         return createEventsButton
     },
     buildEventForm() {

--- a/src/scripts/eventsTabHandlers.js
+++ b/src/scripts/eventsTabHandlers.js
@@ -1,9 +1,9 @@
 import eventsHTML from "./eventsDomManager"
 
-const eventsHandler = {
-    // Event handler to print new event form to the DOM
-    addNewEventHandler () {
+// const eventsHandler = {
+//     // Event handler to print new event form to the DOM
+//     addNewEventHandler () {
         
 
-    }
-}
+//     }
+// }

--- a/src/scripts/eventsTabHandlers.js
+++ b/src/scripts/eventsTabHandlers.js
@@ -1,1 +1,9 @@
 import eventsHTML from "./eventsDomManager"
+
+const eventsHandler = {
+    // Event handler to print new event form to the DOM
+    addNewEventHandler () {
+        
+
+    }
+}


### PR DESCRIPTION
# Description
Clears events when viewing friends/messages/etc through nav bar

Applies to issue #.5Events (issue number)

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)


# Testing Instructions

1. `git fetch`
2. `git checkout rw-clearnav-nutshell`
3. `cd src/lib` in terminal
4. `grunt`
5. open http://localhost:8080 
6. click on events in nav bar multiple times to make sure it's only printing once
7. click on messages to verify the events clearing.



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
