### PR TITLE
Added class to form and set the display to none. Event handler remove…

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -6,3 +6,7 @@ ul {
 .navbar-nav li {
   list-style-type: none;
 }
+
+.is--hidden {
+  display: none;
+}

--- a/src/scripts/eventsAppender.js
+++ b/src/scripts/eventsAppender.js
@@ -9,7 +9,6 @@ const eventsAppender = {
         // Appends the  add button, form and save button from eventsDomManager.js to the DOM
         eventSection.appendChild(buildEventForm.buildEventButton());
         eventSection.appendChild(buildEventForm.buildEventForm());
-        eventSection.appendChild(buildEventForm.eventSaveButton());
         return eventSection;
     }
 

--- a/src/scripts/eventsDomManager.js
+++ b/src/scripts/eventsDomManager.js
@@ -1,16 +1,18 @@
 // This module imports the functions in constructors.js and calls them to create the input form for new events.
 import buildHTML from "./constructors"
+import handlers from "./eventsTabHandlers"
 // Object to export that holds functions as methods.
 const buildEventFormHTML = {
     // Function to build the HTML form
     buildEventButton() {
         const createEventsButton = buildHTML.buttonCreator("eventsButton", "Add New Event", undefined);
         // Event listener console logs 'clicked' when clicked to demonstrate that it works. Event handler has yet to be added.
-        createEventsButton.addEventListener("click", () => console.log("wow what a dream"));
+        createEventsButton.addEventListener("click", handlers.addNewEventHandler);
         return createEventsButton
     },
     buildEventForm() {
         const form = buildHTML.elementWithTextCreator("form", undefined, "buildFormEvent", undefined);
+        form.className = "is--hidden"
 
         const createEventLabel = buildHTML.elementWithTextCreator("label", "Event Name: ", undefined, undefined);
         console.log(createEventLabel)
@@ -29,14 +31,14 @@ const buildEventFormHTML = {
 
         const eventLocationInput = buildHTML.inputCreator("text", "eventLocation");
         form.append(eventLocationInput)
+
+        const createEventSaveButton = buildHTML.buttonCreator("saveEvent", "Save Event", undefined)
+        // Event listener console logs 'this will save your event' when clicked to demonstrate that it works. Event handler has yet to be added.
+        createEventSaveButton.addEventListener("click", () => console.log("this will save your event"))
+        form.append(createEventSaveButton)
         return form
     },
-    eventSaveButton () {
-        const createEventSaveButton = buildHTML.buttonCreator("saveEvent", "Save Event", undefined)
-           // Event listener console logs 'this will save your event' when clicked to demonstrate that it works. Event handler has yet to be added.
-        createEventSaveButton.addEventListener("click", () => console.log("this will save your event"))
-        return createEventSaveButton
-    }
+
 
 
 

--- a/src/scripts/eventsDomManager.js
+++ b/src/scripts/eventsDomManager.js
@@ -6,7 +6,7 @@ const buildEventFormHTML = {
     // Function to build the HTML form
     buildEventButton() {
         const createEventsButton = buildHTML.buttonCreator("eventsButton", "Add New Event", undefined);
-        // Event listener console logs 'clicked' when clicked to demonstrate that it works. Event handler has yet to be added.
+        // Event listener removes the class is--hidden from the element and prints the form to the dom when clicked
         createEventsButton.addEventListener("click", handlers.addNewEventHandler);
         return createEventsButton
     },

--- a/src/scripts/eventsTabHandlers.js
+++ b/src/scripts/eventsTabHandlers.js
@@ -3,7 +3,9 @@ import eventsHTML from "./eventsDomManager"
 const eventsHandler = {
     // Event handler to print new event form to the DOM
     addNewEventHandler () {
+        // Selecting the element with the class is--hidden and storing it in the variable formSection
         let formSection = document.querySelector(".is--hidden")
+        // Removes the class is--hidden from the element formSection
         formSection.classList.remove("is--hidden")
         
 

--- a/src/scripts/eventsTabHandlers.js
+++ b/src/scripts/eventsTabHandlers.js
@@ -1,9 +1,13 @@
 import eventsHTML from "./eventsDomManager"
 
-// const eventsHandler = {
-//     // Event handler to print new event form to the DOM
-//     addNewEventHandler () {
+const eventsHandler = {
+    // Event handler to print new event form to the DOM
+    addNewEventHandler () {
+        let formSection = document.querySelector(".is--hidden")
+        formSection.classList.remove("is--hidden")
         
 
-//     }
-// }
+    }
+}
+
+export default eventsHandler


### PR DESCRIPTION
…s that class when the add new event button is clicked.

# Description

Added the class of "is--hidden" to the form. Used css to target the form and set the display to none.

Applies to issue #1  (events) (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions

1. `git fetch`
2. `git checkout rw-neweventhandler-nutshell`
3. cd src/lib
4. run grunt
5. go to http://localhost:8080
6. Click on events in the nav bar
7. Click on add new event button
8. verify that event form prints to the DOM :)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
