### PR TITLE
Prefilling edit forms

### DIFF
--- a/src/scripts/eventsDomManager.js
+++ b/src/scripts/eventsDomManager.js
@@ -57,7 +57,6 @@ const buildEventFormHTML = {
         section.append(eventEditButton)
 
         return section;
-
     },
     buildEditEventForm(editedEvent) {
         const editForm = buildHTML.elementWithTextCreator("editForm", undefined, `editForm--${editedEvent.id}`, undefined);
@@ -67,18 +66,21 @@ const buildEventFormHTML = {
         console.log(createEventLabel)
         editForm.append(createEventLabel)
 
-        const newEventInput = buildHTML.inputCreator("text", "newEvent");
+        const newEventInput = buildHTML.inputCreator("text", `editEvent--${editedEvent.id}`);
+        newEventInput.value = `${editedEvent.name}`
         editForm.append(newEventInput)
 
         const createEventDateLabel = buildHTML.elementWithTextCreator("label", "Date: ", undefined, undefined);
         editForm.append(createEventDateLabel);
-        const eventDateInput = buildHTML.inputCreator("date", "newEventDate");
+        const eventDateInput = buildHTML.inputCreator("date", `editEventDate--${editedEvent.id}`);
+        eventDateInput.value = `${editedEvent.date}`
         editForm.append(eventDateInput);
 
         const createEventLocationLabel = buildHTML.elementWithTextCreator("label", "Event Location: ", undefined, undefined);
         editForm.append(createEventLocationLabel);
 
-        const eventLocationInput = buildHTML.inputCreator("text", "eventLocation");
+        const eventLocationInput = buildHTML.inputCreator("text", `editedEventLocation--${editedEvent.id}`);
+        eventLocationInput.value = `${editedEvent.location}`
         editForm.append(eventLocationInput)
 
         const saveEditedEvent = buildHTML.buttonCreator("saveEditedEvent", "Save", undefined)

--- a/src/scripts/eventsTabHandlers.js
+++ b/src/scripts/eventsTabHandlers.js
@@ -32,6 +32,7 @@ const eventsHandler = {
     editEventHandler() {
         let editFormSection = document.querySelector(".edit-form-is--hidden");
         editFormSection.classList.remove("edit-form-is--hidden")
+        
     }
 }
 


### PR DESCRIPTION
# Description

Edit event form has prefilled inputs from the object.
Applies to issue #21 (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions

1. `git fetch --all`
2. `git checkout rw-editfunction-nutshell`
3. cd src/lib
4. run grunt
5. open localhost:8080
6. hit edit button and see if values are prefilled.



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
